### PR TITLE
Fix deprecation warning for pandas.tslib

### DIFF
--- a/cufflinks/plotlytools.py
+++ b/cufflinks/plotlytools.py
@@ -153,7 +153,7 @@ def _to_iplot(self,colors=None,colorscale=None,kind='scatter',mode='lines',symbo
 	else:
 		lines_plotly=[Scatter(lines[key]) for key in keys]
 	for trace in lines_plotly:
-		if isinstance(trace['name'],pd.tslib.Timestamp):
+		if isinstance(trace['name'], pd.Timestamp):
 			trace.update(name=str(trace['name']))
 
 	if bestfit:


### PR DESCRIPTION
At the moment, running cufflinks with Plotly in a Jupyter notebook will pop up a nasty deprecation warning for pandas.tslib. As far as I can tell, this was the only use. This change removes the deprecation warning and, as far as I can tell, matches currently plotly behaviour.