### PR TITLE
fix deprecation warning in pandas 0.20 for tslib.Timestamp

### DIFF
--- a/cufflinks/plotlytools.py
+++ b/cufflinks/plotlytools.py
@@ -12,9 +12,10 @@ from . import offline
 from . import auth
 from . import ta
 
-
 __TA_KWARGS = ['min_period','center','freq','how','rsi_upper','rsi_lower','boll_std','fast_period',
 			   'slow_period','signal_period']
+
+
 
 
 def iplot_to_dict(data):
@@ -153,7 +154,7 @@ def _to_iplot(self,colors=None,colorscale=None,kind='scatter',mode='lines',symbo
 	else:
 		lines_plotly=[Scatter(lines[key]) for key in keys]
 	for trace in lines_plotly:
-		if isinstance(trace['name'],pd.tslib.Timestamp):
+		if isinstance(trace['name'], pd.Timestamp):
 			trace.update(name=str(trace['name']))
 
 	if bestfit:

--- a/cufflinks/quant_figure.py
+++ b/cufflinks/quant_figure.py
@@ -25,6 +25,7 @@ from . import colors
 from . import auth
 from . import date_tools
 
+
 __QUANT_FIGURE_DATA = ['kind','showlegend','datalegend','name','slice','resample','bestfit',
 						'text','title','yTitle','secondary_y_title','bestfit_colors','kind',
 						'colorscale','xTitle','colors','secondary_y']
@@ -320,9 +321,9 @@ class QuantFig(object):
 				date1=date0
 				date0=df.index[0]
 
-		if isinstance(date0,pd.tslib.Timestamp):
+		if isinstance(date0, pd.Timestamp):
 			date0=date_tools.dateToString(date0,to_strfmt)
-		if isinstance(date1,pd.tslib.Timestamp):
+		if isinstance(date1, pd.Timestamp):
 			date1=date_tools.dateToString(date1,to_strfmt)
 		d={'x0':date0,'x1':date1,'y0':y0,'y1':y1}
 		d.update(**kwargs)


### PR DESCRIPTION
import path which is now pd.Timestamp
pd.tslib.Timestamp path is deprecated in 0.20