### PR TITLE
Add TA-Lib dependency to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,5 @@ setup(name='cufflinks',
       keywords = ['pandas', 'plotly', 'plotting'],
       url = 'https://github.com/santosjorge/cufflinks',
       packages=['cufflinks'],
-      install_requires = ['pandas','plotly>=2.0.0','colorlover>=0.2'],
+      install_requires = ['pandas','plotly>=2.0.0','colorlover>=0.2','TA-Lib==0.4.10'],
 	  zip_safe=False)


### PR DESCRIPTION
A lot of the TA-Lib-related problems people are having lately stems from the fact that the TA-Lib dependency is only declared in `requirements.txt`, but people just doing a `pip install cufflinks` aren't seeing that - pip doesn't care about `requirements.txt`, it only cares about `install_requires`. So this syncs it up.

On a tangent - what benefit is this TA-Lib thing adding that justifies introducing such an annoying dependency which requires you to manually compile some random library off of SourceForge and forcefully add it to `LD_LIBRARY_PATH` (since many Linux environments don't link against `/usr/local/lib` by default).