### PR TITLE
Pass OHLC(v) mapping to plotly in QuantFigure.iplot()

### DIFF
--- a/cufflinks/quant_figure.py
+++ b/cufflinks/quant_figure.py
@@ -1171,7 +1171,7 @@ class QuantFig(object):
 				shapes[k].append(v)
 			else:
 				shapes[k]=[v]
-		for _ in [data,layout,
+		for _ in [data,layout, self._d,
 				  self.theme,{'annotations':annotations['values']},
 				  annotations['params'],shapes]:
 			if _:


### PR DESCRIPTION
## Summary 
In the class 'QuantFigure', the method `iplot()` (and `figure()`) does not pass the column mapping stored in `_d` to the candlestick plot. This results in the `figure` or `plot` to use the default values of `Open`, `High`, `Low` and `Close`

## Fix
Pass `self._d` to the dictionary , this will mean that `_d` will always be passed as arguments when [constructing the figure within iplot](
https://github.com/santosjorge/cufflinks/blob/master/cufflinks/quant_figure.py#L1181)

If there's a better way, let me know and I'll be happy to amend the PR.

## Expected Result
Custom column mappings for OHLC be used when calling `qf.iplot()`. 

## Actual Result
Default columns for OHLC are used. (ie `Open`, `High`, `Low` and `Close`)

## Example
I have a dataframe with the following columns:
```Python
￼>>> df2.columns
Index(['Open', 'High', 'Low', 'Close', 'Adj. Open', 'Adj. High', 'Adj. Close',
       'Adj. Low', 'Volume'],
      dtype='object')
```

```python console
>>> df2.head()
             Open   High    Low  Close  Adj. Open  Adj. High  Adj. Close  \
Date                                                                       
1980-12-12  28.75  28.87  28.75  28.75   0.422706   0.424470    0.422706   
1980-12-15  27.38  27.38  27.25  27.25   0.402563   0.402563    0.400652   
1980-12-16  25.37  25.37  25.25  25.25   0.373010   0.373010    0.371246   
1980-12-17  25.87  26.00  25.87  25.87   0.380362   0.382273    0.380362   
1980-12-18  26.63  26.75  26.63  26.63   0.391536   0.393300    0.391536   

            Adj. Low     Volume  
Date                             
1980-12-12  0.422706  2093900.0  
1980-12-15  0.400652   785200.0  
1980-12-16  0.371246   472000.0  
1980-12-17  0.380362   385900.0  
1980-12-18  0.391536   327900.0  
```
In my dataframe, all the prices with `Adj. ` has been adjusted due to splits.

If I create a new quantfig with a custom columns for these adjusted prices, I can see that they have been created properly in the object.

```python console
>>> columns = { 'open': 'Adj. Open', 'close': 'Adj. Close', 'high': 'Adj. High', 'low':  'Adj. Low', 'volume': 'Volume'}
>>> qf = cf.QuantFig(df2.head(100),name='Adjusted stock prices', columns=columns)
>>> qf._d

{'close': 'Adj. Close',
 'high': 'Adj. High',
 'low': 'Adj. Low',
 'open': 'Adj. Open',
 'volume': 'Volume'}

```
Add a study and plot the graph
```
>>> qf.add_bollinger_bands(fill=True)
>>> qf.iplot()
```
On the graph, it'll show that the bollinger band study used the correct column mapping, whereas the candlestick graph will use the default values of `Open`, `High`, `Low` and `Close`

## Screenshots
### Without changes
![newplot 2](https://user-images.githubusercontent.com/4985674/31067442-addb833c-a79e-11e7-8d1b-02dbb30f72fb.png)

### With Changes:
![newplot 1](https://user-images.githubusercontent.com/4985674/31067431-a5a90ac2-a79e-11e7-814e-75ddcbea5f8d.png)
