### PR TITLE
Fix offline plots outside of notebooks

### DIFF
--- a/cufflinks/plotlytools.py
+++ b/cufflinks/plotlytools.py
@@ -1051,11 +1051,20 @@ def _iplot(self,data=None,layout=None,filename='',sharing=None,
 			path=filename+'.png'
 		return display(Image(path))
 	elif asPlot:
-		return py.plot(figure,sharing=sharing,filename=filename,validate=validate)
+		if offline.is_offline() and not online:
+			return offline.py_offline.plot(figure, filename=filename, validate=validate)
+		else:
+			return py.plot(figure, sharing=sharing, filename=filename, validate=validate)
 	elif asUrl:
-		return py.plot(figure,sharing=sharing,filename=filename,validate=validate,auto_open=False)
+		if offline.is_offline() and not online:
+			return offline.py_offline.plot(figure, filename=filename, validate=validate,
+										   auto_open=False)
+		else:
+			return py.plot(figure, sharing=sharing, filename=filename, validate=validate,
+						   auto_open=False)
 	else:
-		return iplot(figure,sharing=sharing,filename=filename,validate=validate,online=online)
+		return iplot(figure, sharing=sharing, filename=filename, validate=validate, online=online)
+
 
 
 def get_colors(colors,colorscale,keys,asList=False):


### PR DESCRIPTION
Currently cufflinks users calling iplot outside of notebooks get an error message about connecting to plotly, even if they user `.iplot(asPlot=True)` or do `cufflinks.go_offline()` prior to the `.iplot()` call.

When examinig the code we notice that asPlot mode implicitly tries to connect to plotly.

This PR changes that behaviour so that users without a plotl account can generate plotly graph in an html file outside of notebooks. 

With this PR, in a .py file one can do:
```python
import pandas as pd
import cufflinks
cufflinks.go_offline()
pd.Series([1,2,3]).iplot(asPlot=True)
```
which will save the figure to an html file an open it.