### PR TITLE
fixed selecting correct colorscale

### DIFF
--- a/cufflinks/colors.py
+++ b/cufflinks/colors.py
@@ -686,12 +686,14 @@ def get_scales(scale=None, n=None):
             is_reverse = True
         d = copy.deepcopy(_scales_names[scale.lower()])
         keys = list(map(int, list(d.keys())))
+        cs = None
         if n:
             if n in keys:
                 cs = d[str(n)]
             elif n < min(keys):
                 cs = d[str(min(keys))]
-        cs = d[str(max(keys))]
+        if cs is None:
+            cs = d[str(max(keys))]
         if is_reverse:
             cs.reverse()
         return cs


### PR DESCRIPTION
There are different colorscales for one name depending on number of elements, but it always is selected as for maximum value.
How to check. Code should show same plots
```
import pandas as pd
import cufflinks as cf
test_df = pd.DataFrame(dict(a=[1,2,3], b=[2,3,4], c=[3,4,5]))
test_df.iplot(kind='scatter', colors=cf.colors._scales_names['ylorrd']['3'])
test_df.iplot(kind='scatter', colorscale='ylorrd')
```