### PR TITLE
Fix bug when using y and secondary_y

### DIFF
--- a/cufflinks/plotlytools.py
+++ b/cufflinks/plotlytools.py
@@ -812,7 +812,12 @@ def _iplot(self,kind='scatter',data=None,layout=None,filename='',sharing=None,ti
 					df=pd.DataFrame({df.name:df})
 				if x:
 					df=df.set_index(x)
-				if y:
+				if y and secondary_y:
+					if isinstance(secondary_y, str):
+						df=df[[y, secondary_y]]
+					else:
+						df=df[[y] + secondary_y]
+				elif y:
 					df=df[y]
 				if kind=='area':
 					df=df.transpose().fillna(0).cumsum().transpose()


### PR DESCRIPTION
There was a bug that made it so that you couldn't specify both `y` and `secondary_y`, I've fixed this which makes it much easier to have both y-axes used for plots.