### PR TITLE
Add classifiers to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,16 +6,23 @@ here = path.abspath(path.dirname(__file__))
 with io.open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
     requires = f.read().split()
 
-setup(name='cufflinks',
-      version='0.14.5',
-      description='Productivity Tools for Plotly + Pandas',
-      author='Jorge Santos',
-      author_email='santos.jorge@gmail.com',
-      license='MIT',
-      keywords = ['pandas', 'plotly', 'plotting'],
-      url = 'https://github.com/santosjorge/cufflinks',
-      packages=['cufflinks'],
-      package_data={'cufflinks': ['../helper/*.json']},
-      include_package_data=True,
-      install_requires=requires,
-	  zip_safe=False)
+setup(
+    name='cufflinks',
+    version='0.14.5',
+    description='Productivity Tools for Plotly + Pandas',
+    author='Jorge Santos',
+    author_email='santos.jorge@gmail.com',
+    license='MIT',
+    keywords=['pandas', 'plotly', 'plotting'],
+    url='https://github.com/santosjorge/cufflinks',
+    packages=['cufflinks'],
+    package_data={'cufflinks': ['../helper/*.json']},
+    include_package_data=True,
+    install_requires=requires,
+    classifiers=[
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
+    ]
+    zip_safe=False
+)


### PR DESCRIPTION
Classifiers are metadata about packages on PyPI. The information about Python version support shows on the PyPI project page and are used by tools such as caniusepython3. Also changed formatting to be more consistent.