### PR TITLE
Fix bestfit

### DIFF
--- a/cufflinks/pandastools.py
+++ b/cufflinks/pandastools.py
@@ -63,7 +63,7 @@ def bestfit(self):
 						"please run " \
 						"pip install statsmodels" )
 
-	x=pd.Series(list(range(1,len(self)+1)),index=self.index)
+	x=self.index.values
 	x=sm.add_constant(x)
 	model=sm.OLS(self,x)
 	fit=model.fit()

--- a/cufflinks/pandastools.py
+++ b/cufflinks/pandastools.py
@@ -72,7 +72,7 @@ def bestfit(self):
 	# the below methods have been deprecated in Pandas
 	# model=pd.ols(x=x,y=self,intercept=True)
 	# best_fit=model.y_fitted
-	best_fit.formula='%.2f*x+%.2f' % (vals[0],vals[1])
+	best_fit.formula='%.2f*x+%.2f' % (vals[1],vals[0])
 	return best_fit
 
 def normalize(self,asOf=None,multiplier=100):

--- a/cufflinks/plotlytools.py
+++ b/cufflinks/plotlytools.py
@@ -165,6 +165,9 @@ def _to_iplot(self,colors=None,colorscale=None,kind='scatter',mode='lines',inter
 			trace.update(name=str(trace['name']))
 
 	if bestfit:
+		if isinstance(df.index,pd.MultiIndex):
+			raise TypeError('x cannot be empty for MultiIndex dataframes')
+
 		if type(bestfit)==list:
 			keys=bestfit
 		d={}

--- a/cufflinks/version.py
+++ b/cufflinks/version.py
@@ -1,1 +1,1 @@
-__version__ = "0.15"
+__version__ = "0.16dev"

--- a/tests.py
+++ b/tests.py
@@ -5,6 +5,7 @@
 
 import cufflinks as cf
 import pandas as pd
+import numpy as np
 import unittest
 from nose.tools import assert_equals
 
@@ -221,6 +222,24 @@ def quant_figure_tests():
 	qf.add_bollinger_bands()
 	return qf.figure()
 
+def bestfit():
+
+	df = cf.datagen.scatter()
+	df['x'] = np.random.randint(1, 20, df.shape[0])
+	df['y'] = df['x']
+	df = df[['x', 'y']]
+
+	options = {
+		'kind': ['scatter'],
+		'bestfit': [True],
+	}
+
+	def bestfit(self, **kwargs):
+		self._iplot(df, **kwargs)
+
+	_generate_tests(TestIPlot, bestfit, 'bestfit', options)
+
+
 # test generators
 
 
@@ -269,6 +288,7 @@ test_irregular_subplots()
 color_normalize_tests()
 quant_figure_tests()
 # ta_tests()
+bestfit()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello,
I faced an issue where the bestfit line was not correct.

For instance

```
import pandas as pd
import numpy as np
df = cf.datagen.scatter()
df['x'] = np.random.randint(1, 10, df.shape[0])
df['y'] = df['x']

df.iplot(kind='scatter', mode='markers', x='x', y='y', bestfit=True)

```
should return a perfect fit, although this does not happen.

I think this PR solves the issue.
Cheers