### PR TITLE
make the theme parameter case insensitive.

### DIFF
--- a/cufflinks/tools.py
+++ b/cufflinks/tools.py
@@ -61,6 +61,7 @@ def getTheme(theme=None):
 	if not theme:
 		theme = auth.get_config_file()['theme']
 
+	theme = theme.lower()
 	if theme in THEMES:
 		return updateColors(copy.deepcopy(THEMES[theme]))
 	else:


### PR DESCRIPTION
This PR made one improvement:

Now methods like `iplot` can use the `theme` parameter case insensitive:

* `df.iplot(theme='white')`
* `df.iplot(theme='Solar')`
* `df.iplot(theme='PEARL')`

are all valid.