### PR TITLE
Modify import for plotly v4 and adding chart_studio dependency as recommended

### DIFF
--- a/cufflinks/tools.py
+++ b/cufflinks/tools.py
@@ -3,7 +3,7 @@ import copy
 import numpy as np
 import pandas as pd
 import plotly.offline as py_offline
-import plotly.plotly as py
+import chart_studio.plotly as py
 from plotly.graph_objs import Figure, Scatter, Line
 from plotly.tools import make_subplots
 # from plotly.graph_objs.layout import XAxis, YAxis

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+chart-studio
 numpy>=1.9.2
 pandas>=0.19.2
 plotly>=3.0.0,<4.0.0a0


### PR DESCRIPTION
This is a fix that enables to import `cufflinks` without the error reported at #194 .

Not sure how you want to handle the version upgrade for both cufflinks and plotly in the requirements.txt though

