### PR TITLE
Correcting Pandas FutureWarning

### DIFF
--- a/cufflinks/pandastools.py
+++ b/cufflinks/pandastools.py
@@ -93,9 +93,9 @@ def normalize(self,asOf=None,multiplier=100):
 			Factor by which the results will be adjusted
 	"""
 	if not asOf:
-		x0=self.ix[0]
+		x0=self.iloc[0]
 	else:
-		x0=self.ix[asOf]
+		x0=self.loc[asOf]
 	return self/x0*multiplier
 
 def read_google(url,**kwargs):


### PR DESCRIPTION
/opt/conda/lib/python3.7/site-packages/cufflinks/pandastools.py:96: FutureWarning:

.ix is deprecated. Please use
.loc for label based indexing or
.iloc for positional indexing

See the documentation here:
http://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#ix-indexer-is-deprecated