### PR TITLE
Fix subplots issues for plotly 4

### DIFF
--- a/cufflinks/tools.py
+++ b/cufflinks/tools.py
@@ -773,7 +773,7 @@ def subplots(figures,shape=None,
 				break
 		for _ in figures[i]['data']:
 			for axe in lr:
-				_.update({'{0}axis'.format(axe[0]):axe})
+				_.update(axe.trace_kwargs)
 			sp['data'].append(_)
 	# Remove extra plots
 	for k in list(sp['layout'].keys()):


### PR DESCRIPTION
I tried to fix subplots issues https://github.com/santosjorge/cufflinks/issues/196#issuecomment-526695267 mentioned.

Variable `axe` would be [SubplotRef](https://github.com/plotly/plotly.py/blob/7cb8d6b87cbcfa477a806701c37331f953e2497e/packages/python/plotly/plotly/subplots.py#L34) in Plotly 4.