### PR TITLE
Fix misc. issues for plotly v4.

### DIFF
--- a/cufflinks/__init__.py
+++ b/cufflinks/__init__.py
@@ -20,7 +20,7 @@ from . import ta
 from .helper import _printer as help
 from .plotlytools import *
 from plotly.graph_objs import *
-from plotly.plotly import plot
+from chart_studio.plotly import plot
 from .colors import cnames, get_colorscale
 from .utils import pp
 from .tools import subplots,scatter_matrix,figures,getLayout,getThemes,getTheme

--- a/cufflinks/plotlytools.py
+++ b/cufflinks/plotlytools.py
@@ -1,5 +1,5 @@
 import pandas as pd
-import plotly.plotly as py
+import chart_studio.plotly as py
 import time
 import copy
 # from plotly.graph_objs import *
@@ -1401,10 +1401,9 @@ def iplot(figure,validate=True,sharing=None,filename='',
 		# if not figure.get('layout', None):
 		# 	figure['layout'] = {}
 		try:
-			filename=figure['layout']['title']
+			filename=figure.layout['title']['text']
 		except:
 			filename='Plotly Playground {0}'.format(time.strftime("%Y-%m-%d %H:%M:%S"))
-
 	## Dimensions
 	if not dimensions:
 		dimensions=(800,500) if not auth.get_config_file()['dimensions'] else auth.get_config_file()['dimensions']

--- a/cufflinks/quant_figure.py
+++ b/cufflinks/quant_figure.py
@@ -93,7 +93,7 @@ class QuantFig(object):
 		
 		# self.theme initial values
 		self.theme['theme']=kwargs.pop('theme',auth.get_config_file()['theme'])
-		self.theme['up_color']=kwargs.pop('up_color','java')  # java
+		self.theme['up_color']=kwargs.pop('up_color','#17BECF')  # java
 		self.theme['down_color']=kwargs.pop('down_color','grey')
 		
 		# self.panels initial values

--- a/cufflinks/tools.py
+++ b/cufflinks/tools.py
@@ -3,7 +3,7 @@ import copy
 import numpy as np
 import pandas as pd
 import plotly.offline as py_offline
-import plotly.plotly as py
+import chart_studio.plotly as py
 from plotly.graph_objs import Figure, Scatter, Line
 from plotly.tools import make_subplots
 # from plotly.graph_objs.layout import XAxis, YAxis
@@ -773,7 +773,7 @@ def subplots(figures,shape=None,
 				break
 		for _ in figures[i]['data']:
 			for axe in lr:
-				_.update({'{0}axis'.format(axe[0]):axe})
+				_.update(axe.trace_kwargs)
 			sp['data'].append(_)
 	# Remove extra plots
 	for k in list(sp['layout'].keys()):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 numpy>=1.9.2
 pandas>=0.19.2
-plotly>=3.0.0,<4.0.0a0
+plotly>=4.0.0
+chart-studio>=1.0.0
+statsmodels>=0.10.1
 six>=1.9.0
 colorlover>=0.2.1
 setuptools>=34.4.1


### PR DESCRIPTION
I tried to fix some issues for plotly v4.

#### chart_studio https://github.com/santosjorge/cufflinks/pull/195 https://github.com/santosjorge/cufflinks/pull/198
- only replace `plotly.plotly` to `chart_studio.plotly`
#### subplots https://github.com/santosjorge/cufflinks/issues/196#issuecomment-526695267
- Variable `axe` would be [SubplotRef](https://github.com/plotly/plotly.py/blob/7cb8d6b87cbcfa477a806701c37331f953e2497e/packages/python/plotly/plotly/subplots.py#L34) in Plotly 4.
#### [Cufflinks Tutorial - Offline.ipynb](https://github.com/santosjorge/cufflinks/blob/master/Cufflinks%20Tutorial%20-%20Offline.ipynb)
- Bottom end online plot try to find filename from figure title. It still has `text` key under `title`. I don't have plotly account, has not test publishing.

#### [Cufflinks Tutorial - Quantfig.ipynb](https://github.com/santosjorge/cufflinks/blob/master/Cufflinks%20Tutorial%20-%20Quantfig.ipynb)
- `up_color` default's java is missing.