### PR TITLE
Fix bestfit() case when the index is a pd.DatetimeIndex

### DIFF
--- a/cufflinks/pandastools.py
+++ b/cufflinks/pandastools.py
@@ -63,7 +63,11 @@ def bestfit(self):
 						"please run " \
 						"pip install statsmodels" )
 
-	x=self.index.values
+	if isinstance(self.index, pd.DatetimeIndex):
+		x=pd.Series(list(range(1,len(self)+1)),index=self.index)
+	else:
+		x=self.index.values
+		
 	x=sm.add_constant(x)
 	model=sm.OLS(self,x)
 	fit=model.fit()

--- a/tests.py
+++ b/tests.py
@@ -288,7 +288,7 @@ test_irregular_subplots()
 color_normalize_tests()
 quant_figure_tests()
 # ta_tests()
-# bestfit()
+bestfit()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A recent commit (https://github.com/santosjorge/cufflinks/commit/a8f6f9440b50f0b8a2bd56f10ec9d50876d28ca2) changed the behavior of bestfit, and broke the function for timeseries (I noticed it when testing the jupyter notebooks).  This small fix takes care of it.  I also re-enabled the bestfit in the tests, and it finished OK.  Without this fix, 3 or 4 of the demo jupyter notebooks don't run.