### PR TITLE
Update _set_axis(): fix layout property deletion bug

### DIFF
--- a/cufflinks/tools.py
+++ b/cufflinks/tools.py
@@ -1184,7 +1184,7 @@ def _set_axis(self,traces,on=None,side='right',title=''):
 		id='{0}axis{1}'.format(k[0],k[-1:])
 		if k not in fig.axis['ref_axis']:
 			try:
-				del fig['layout'][id]
+				del fig['layout']._props[id]
 			except KeyError:
 				pass
 


### PR DESCRIPTION
`fig['layout']` in `_set_axis()`, which is an object of `plotly.graph_objs.Layout` should not be used with `del` because the class and its all parent classes do not implement `__delitem__`. So, it will raise `AttributeError: __delitem__` instead of `KeyError`.

So, I fixed it by accessing `_props` directly. But it might not look good because the `underscore + property` is usually called inside of an instance method, not the outside of the object. Any comments or fixes will be welcomed!