### PR TITLE
Replaced deprecated pd.np submodule with np.

### DIFF
--- a/cufflinks/plotlytools.py
+++ b/cufflinks/plotlytools.py
@@ -1,6 +1,7 @@
 import pandas as pd
 import time
 import copy
+import numpy as np
 # from plotly.graph_objs import *
 from plotly.graph_objs import Figure, Layout, Bar, Box, Scatter, FigureWidget, Scatter3d, Histogram, Heatmap, Surface, Pie
 import plotly.figure_factory as ff


### PR DESCRIPTION
As pd.np is now deprecated, I replaced it with np, in cufflinks/plotlytools.py.