### PR TITLE
Update colors.py

### DIFF
--- a/cufflinks/colors.py
+++ b/cufflinks/colors.py
@@ -37,19 +37,20 @@ def to_rgba(color, alpha):
             to_rgba('#f03',0.7)
             to_rgba('rgb(23,23,23)',.5)
     """
+
     if type(color) == tuple:
         color, alpha = color
     color = color.lower()
     if 'rgba' in color:
         cl = list(eval(color.replace('rgba', '')))
         if alpha:
-            cl[3] = alpha
+            cl[3] = float(alpha)
         return 'rgba' + str(tuple(cl))
     elif 'rgb' in color:
         r, g, b = eval(color.replace('rgb', ''))
-        return 'rgba' + str((r, g, b, alpha))
+        return 'rgba' + str((r, g, b, float(alpha)))
     else:
-        return to_rgba(hex_to_rgb(color), alpha)
+        return to_rgba(hex_to_rgb(color), float(alpha))
 
 
 def hex_to_rgb(color):


### PR DESCRIPTION
forces `alpha` to be a `float`.  using jupyterlab, it seems like it is coming thru as a `np.float` which is then causing plotly to fallover

to install:

(for poetry)
cufflinks = { git = "https://github.com/aa403/cufflinks.git", branch = "patch-1" }

(for pip / requirements.txt)
cufflinks @ git+https://github.com/aa403/cufflinks@patch-1


SO discussion of the issue here:
https://stackoverflow.com/questions/51691172/plotly-value-error-invalid-property-for-colour
